### PR TITLE
Fix Web3Auth provider, FuseSDK SCA, and Axios Webpack

### DIFF
--- a/w3a-quick-start/config-overrides.js
+++ b/w3a-quick-start/config-overrides.js
@@ -30,5 +30,15 @@ module.exports = function override(config) {
       fullySpecified: false,
     },
   });
+
+  // Webpack customization for axios issue, see:
+  // https://github.com/facebook/create-react-app/pull/12021#issuecomment-1108426483
+  config.module.rules = config.module.rules.map(rule => {
+    if (rule.oneOf instanceof Array) {
+      rule.oneOf[rule.oneOf.length - 1].exclude = [/\.(js|mjs|jsx|cjs|ts|tsx)$/, /\.html$/, /\.json$/];
+    }
+    return rule;
+  });
+
   return config;
 };

--- a/w3a-quick-start/src/App.tsx
+++ b/w3a-quick-start/src/App.tsx
@@ -42,22 +42,10 @@ console.log(web3auth);
 
 //  const check = ethers.baseWallet.privateKey
 
-const main = async () => {
-  const provider = new ethers.providers.JsonRpcProvider(
-    web3auth.provider as any
-  );
-  const signer = provider.getSigner();
-  const publicApiKey = "pk_wEP0gTlc3jcvBXEDpSnXBgbQ";
-  const fuseSDK = await FuseSDK.init(publicApiKey, signer);
-  const walletAddress = await fuseSDK.wallet.getSender();
-  console.log(`Sender Address is ${walletAddress}`);
-};
-
-main();
-
 function App() {
   const [provider, setProvider] = useState<IProvider | null>(null);
   const [loggedIn, setLoggedIn] = useState(false);
+  const [fuseSDK, setFuseSDK] = useState<FuseSDK | null>(null);
 
   useEffect(() => {
     const init = async () => {
@@ -77,6 +65,19 @@ function App() {
 
     init();
   }, []);
+
+  useEffect(() => {
+    (async() => {
+      if(loggedIn && provider) {
+        const ethersProvider = new ethers.providers.Web3Provider(
+          web3auth.provider as any
+        );
+        const signer = ethersProvider.getSigner();
+        const publicApiKey = "pk_wEP0gTlc3jcvBXEDpSnXBgbQ";
+        setFuseSDK(await FuseSDK.init(publicApiKey, signer));
+      }
+    })()
+  }, [provider, loggedIn])
 
   const login = async () => {
     // IMP START - Login
@@ -115,7 +116,8 @@ function App() {
 
     // Get user's Ethereum public address
     const address = await web3.eth.getAccounts();
-    uiConsole(address);
+    const scaAddress = fuseSDK?.wallet.getSender();
+    uiConsole(`EOA: ${address}`, `SCA: ${scaAddress}`);
   };
 
   // const pkey = async () => {


### PR DESCRIPTION
Fix:
- Web3Auth provider was initializing early
- FuseSDK was not creating smart contract account 
- "axios_1.default.create is not a function" through Webpack Rewired Create React App config overrides